### PR TITLE
Let steward files determine sort order; move printing responsibility out of Stewfinder

### DIFF
--- a/exe/stewfinder
+++ b/exe/stewfinder
@@ -3,4 +3,4 @@ require 'stewfinder'
 
 filename = ARGV[0] ? File.absolute_path(ARGV[0]) : Dir.pwd
 
-Stewfinder.new(filename).find
+Stewfinder.new(filename).print_stewards

--- a/lib/stewfinder.rb
+++ b/lib/stewfinder.rb
@@ -13,7 +13,7 @@ class Stewfinder
     if stewards.empty?
       puts 'None'
     else
-      puts ' - ' + stewards.uniq.sort.join("\n - ")
+      puts ' - ' + stewards.uniq.join("\n - ")
     end
   end
 

--- a/lib/stewfinder.rb
+++ b/lib/stewfinder.rb
@@ -7,13 +7,17 @@ class Stewfinder
   end
 
   def find
-    stewards = get_stewards
+    get_stewards.uniq
+  end
+
+  def print_stewards
+    stewards = find
 
     puts 'Stewards for this file:'
     if stewards.empty?
       puts 'None'
     else
-      puts ' - ' + stewards.uniq.join("\n - ")
+      puts ' - ' + stewards.join("\n - ")
     end
   end
 


### PR DESCRIPTION
The gem should let steward files determine the order of stewards returned rather than forcing an alphanumeric sort. In general, a steward of A/B/C is designating more fine-grained stewardship over files in A/B/C and it makes sense to list them before "more general" stewards in A/B and A. (In the future, it may even be nice for `find` to optionally include the location of the closest steward file for each steward, but we don't need to implement that now.)

Additionally, by moving the printing responsibility out of `Stewfinder#find`, we leave the option for callers to sort the results as they desire.
