### PR TITLE
[incomplete] Add test to demonstrate relative path issue.

### DIFF
--- a/test/finder_test.rb
+++ b/test/finder_test.rb
@@ -19,6 +19,15 @@ module Stewfinder
       assert_equal %w(test2 test1), finder.find
     end
 
+    def test_find_relative_file
+      File.stubs(:exist?).returns(true)
+      YAML.stubs(:load_file).returns(loaded_stewfile)
+
+      finder = Finder.new('/home/test/git/stewfinder/relative_file')
+
+      assert_equal %w(test2 test1 relative_file), finder.find
+    end
+
     def test_find__with_regex
       File.stubs(:exist?).returns(true)
       YAML.stubs(:load_file).returns(loaded_stewfile)
@@ -110,7 +119,8 @@ module Stewfinder
         'test2',
         'test1',
         { 'github_username' => 'test_regex1', 'include' => ['*regex*'] },
-        { 'github_username' => 'test_regex2', 'include' => '*regex*' }
+        { 'github_username' => 'test_regex2', 'include' => '*regex*' },
+        { 'github_username' => 'relative_file', 'include' => 'relative_file' }
       ] }
     end
   end


### PR DESCRIPTION
For another example, if I were to change my entry in in `stewards.yml` for this project to:

```
- github_username: bboe
  include: README.md
```

Then running `stewfinder README.md` does not show `bboe` as a steward of the file.

I also believe (but haven't confirmed) that because the matcher does not include the path to the steward file, a steward file in `lib/foo` that should match on `*.md` will match on `README.md` that is not a child of the `lib/foo` directory, which is not the desired behavior.
